### PR TITLE
Fix compilation issues with newer version of JUCE

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -200,7 +200,7 @@ void MisstortionAudioProcessor::processBlock(AudioSampleBuffer& buffer, MidiBuff
 	if (filterMode != 0 && toneHP > 0) {
 		// filterMode as order means 1st order = 6db/oct, 2nd order = 12db/oct
 		auto coeff = dsp::FilterDesign<float>::designIIRHighpassHighOrderButterworthMethod((float)toneHP, sampleRate, filterMode);
-		m_filterHP.state->coefficients = coeff[0].coefficients;
+		m_filterHP.state->coefficients = coeff[0]->coefficients;
 		m_filterHP.process(dspContext);
 	}
 
@@ -245,7 +245,7 @@ void MisstortionAudioProcessor::processBlock(AudioSampleBuffer& buffer, MidiBuff
 	if (filterMode != 0) {
 		// filterMode as order means 1st order = 6db/oct, 2nd order = 12db/oct
 		auto coeff = dsp::FilterDesign<float>::designIIRLowpassHighOrderButterworthMethod((float)toneLP, sampleRate, filterMode);
-		m_filterLP.state->coefficients = coeff[0].coefficients;
+		m_filterLP.state->coefficients = coeff[0]->coefficients;
 		m_filterLP.process(dspContext);
 	}
 

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -277,7 +277,7 @@ AudioProcessorEditor* MisstortionAudioProcessor::createEditor()
 //==============================================================================
 void MisstortionAudioProcessor::getStateInformation(MemoryBlock& destData)
 {
-	ScopedPointer<XmlElement> xml = new XmlElement("root");
+	auto xml = std::make_unique<XmlElement>("root");
 
 	XmlElement* xmlVersion = new XmlElement("version");
 	xmlVersion->addTextElement(JucePlugin_VersionString);
@@ -301,7 +301,7 @@ void MisstortionAudioProcessor::getStateInformation(MemoryBlock& destData)
 
 void MisstortionAudioProcessor::setStateInformation(const void* data, int sizeInBytes)
 {
-	ScopedPointer<XmlElement> xml = getXmlFromBinary(data, sizeInBytes);
+	std::unique_ptr<XmlElement> xml = getXmlFromBinary(data, sizeInBytes);
 
 	XmlElement* xmlSettings = xml->getChildByName("settings");
 	if (xmlSettings != nullptr) {


### PR DESCRIPTION
JUCE changed some of their internals in the last few years:

- `juce::ScopedPointer` got deprecated in JUCE 5.3.2 and all of its uses were replaced with `std::unique_ptr`. https://github.com/juce-framework/JUCE/commit/ab863a6dc2aa84f3f97502eb6358348e6cb86f23
- `juce::ReferencCountedArray` returns pointers instead of objects as of JUCE 5.4.0. https://github.com/juce-framework/JUCE/commit/1e6bbb8da98448279727df3be71efa52e8605ac2

I accidentally deleted the build I had been using for a while so I had to recompile Thanks for making Misstortion!